### PR TITLE
Include Lock wait timeout to the circuit breaker flow

### DIFF
--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -30,7 +30,8 @@ module Semian
     )
 
     TIMEOUT_ERROR = Regexp.union(
-      /Timeout waiting for a response/i
+      /Timeout waiting for a response/i,
+      /Lock wait timeout exceeded/i
     )
 
     ResourceBusyError = ::Mysql2::ResourceBusyError


### PR DESCRIPTION
In the current Semian code, we don't capture the Lock timeout errors. Due to this during one of the incidents, the circuit breaker didn't kick in. 

We are adding the support for it